### PR TITLE
Deploy testnet2 key funder

### DIFF
--- a/typescript/infra/config/environments/testnet2/funding.ts
+++ b/typescript/infra/config/environments/testnet2/funding.ts
@@ -7,7 +7,7 @@ import { environment } from './chains';
 export const keyFunderConfig: KeyFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-    tag: 'sha-f3509ac',
+    tag: 'sha-27183b1',
   },
   cronSchedule: '45 * * * *', // Every hour at the 45 minute mark
   namespace: environment,


### PR DESCRIPTION
Key funder should now fund on Goerli - before it was being skipped