### PR TITLE
Decrease frequency of Outbox.state() RPCs

### DIFF
--- a/rust/agents/relayer/src/msg/processor.rs
+++ b/rust/agents/relayer/src/msg/processor.rs
@@ -232,7 +232,7 @@ impl MessageProcessor {
 
     /// Spawn a task to update the outbox state gauge.
     async fn metrics_loop(outbox_state_gauge: IntGauge, outbox: Arc<dyn Outbox>) {
-        let mut interval = tokio::time::interval(Duration::from_secs(60));
+        let mut interval = tokio::time::interval(Duration::from_secs(60 * 10));
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
         loop {
             let state = outbox.state().await;

--- a/rust/agents/relayer/src/msg/processor.rs
+++ b/rust/agents/relayer/src/msg/processor.rs
@@ -58,8 +58,7 @@ impl MessageProcessor {
     pub(crate) fn spawn(self) -> Instrumented<JoinHandle<Result<()>>> {
         let span = info_span!("MessageProcessor");
         tokio::spawn(async move {
-            let res = self.main_loop().await;
-            res
+            self.main_loop().await
         })
         .instrument(span)
     }

--- a/rust/agents/relayer/src/msg/processor.rs
+++ b/rust/agents/relayer/src/msg/processor.rs
@@ -57,10 +57,7 @@ impl MessageProcessor {
 
     pub(crate) fn spawn(self) -> Instrumented<JoinHandle<Result<()>>> {
         let span = info_span!("MessageProcessor");
-        tokio::spawn(async move {
-            self.main_loop().await
-        })
-        .instrument(span)
+        tokio::spawn(async move { self.main_loop().await }).instrument(span)
     }
 
     #[instrument(ret, err, skip(self), fields(inbox_name=self.inbox_contracts.inbox.chain_name(), local_domain=?self.inbox_contracts.inbox.local_domain()), level = "info")]

--- a/rust/agents/relayer/src/relayer.rs
+++ b/rust/agents/relayer/src/relayer.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use abacus_base::chains::TransactionSubmissionType;
 use async_trait::async_trait;
 use eyre::Result;
+use tokio::time::MissedTickBehavior;
 use tokio::{sync::mpsc, sync::watch, task::JoinHandle};
 use tracing::{info, info_span, instrument::Instrumented, Instrument};
 
@@ -120,6 +122,8 @@ impl BaseAgent for Relayer {
             info!("Interchain Gas Paymaster not provided, not running sync");
         }
 
+        tasks.push(self.run_outbox_metrics_loop());
+
         run_all(tasks)
     }
 }
@@ -154,6 +158,30 @@ impl Relayer {
             self.core.metrics.last_known_message_leaf_index(),
         );
         checkpoint_fetcher.spawn()
+    }
+
+    fn run_outbox_metrics_loop(&self) -> Instrumented<JoinHandle<Result<()>>> {
+        let outbox = self.outbox().outbox().clone();
+        let outbox_name = outbox.chain_name();
+        let outbox_state_gauge = self
+            .core
+            .metrics
+            .outbox_state()
+            .with_label_values(&[outbox_name]);
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(60 * 10));
+            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            loop {
+                let state = outbox.state().await;
+                match &state {
+                    Ok(state) => outbox_state_gauge.set(*state as u8 as i64),
+                    Err(e) => tracing::warn!(error = %e, "Failed to get outbox state"),
+                };
+
+                interval.tick().await;
+            }
+        })
+        .instrument(info_span!("outbox_metrics_loop"))
     }
 
     /// Helper to construct a new GelatoSubmitter instance for submission to a
@@ -231,7 +259,6 @@ impl Relayer {
         };
 
         let message_processor = MessageProcessor::new(
-            outbox.clone(),
             self.outbox().db().clone(),
             inbox_contracts,
             self.whitelist.clone(),

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -55,7 +55,7 @@ impl ValidatorSubmitter {
 
     /// Spawn a task to update the outbox state gauge.
     async fn metrics_loop(outbox_state_gauge: IntGauge, outbox: CachingOutbox) {
-        let mut interval = tokio::time::interval(Duration::from_secs(60));
+        let mut interval = tokio::time::interval(Duration::from_secs(60 * 10));
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
         loop {
             let state = outbox.state().await;


### PR DESCRIPTION
This changes a couple things:
* I noticed in the relayers that we have a metrics loop that was spawned for each inbox that only calls Outbox.state() every once in a while. Because there's only 1 outbox this is unnecessary, so this changes it to only spawn one loop
* I also think the once per minute is pretty frequent - maybe when we implement watchtowers it'll make sense to have a more accurate outlook as to whether the Outbox has been failed, but even then I expect the watchtowers will be the ones with the more intense monitoring around the failure of outboxes