### PR TITLE
Deploy testnet2 and mainnet agents, use Gelato where we can for all testnet2 contexts

### DIFF
--- a/typescript/infra/config/environments/mainnet/agent.ts
+++ b/typescript/infra/config/environments/mainnet/agent.ts
@@ -23,7 +23,7 @@ export const abacus: AgentConfig<MainnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-58984b5',
+    tag: 'sha-7040e5c',
   },
   aws: {
     region: 'us-east-1',
@@ -80,7 +80,7 @@ export const releaseCandidate: AgentConfig<MainnetChains> = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-58984b5',
+    tag: 'sha-7040e5c',
   },
   aws: {
     region: 'us-east-1',

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -34,6 +34,9 @@ export const abacus: AgentConfig<TestnetChains> = {
   environmentChainNames: chainNames,
   contextChainNames: chainNames,
   validatorSets: validators,
+  gelato: {
+    enabledChains: ['alfajores', 'mumbai', 'goerli'],
+  },
   connectionType: ConnectionType.Http,
   validator: {
     default: {
@@ -97,6 +100,9 @@ export const flowcarbon: AgentConfig<TestnetChains> = {
   environmentChainNames: chainNames,
   contextChainNames: ['alfajores', 'kovan'],
   validatorSets: validators,
+  gelato: {
+    enabledChains: ['alfajores'],
+  },
   connectionType: ConnectionType.HttpQuorum,
   relayer: {
     default: {
@@ -125,10 +131,10 @@ export const releaseCandidate: AgentConfig<TestnetChains> = {
   },
   environmentChainNames: chainNames,
   contextChainNames: chainNames,
-  gelato: {
-    enabledChains: ['alfajores', 'mumbai'],
-  },
   validatorSets: validators,
+  gelato: {
+    enabledChains: ['alfajores', 'mumbai', 'goerli'],
+  },
   connectionType: ConnectionType.HttpQuorum,
   relayer: {
     default: {

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -26,7 +26,7 @@ export const abacus: AgentConfig<TestnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-58984b5',
+    tag: 'sha-7040e5c',
   },
   aws: {
     region: 'us-east-1',
@@ -89,7 +89,7 @@ export const flowcarbon: AgentConfig<TestnetChains> = {
   context: Contexts.Flowcarbon,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-58984b5',
+    tag: 'sha-7040e5c',
   },
   aws: {
     region: 'us-east-1',
@@ -118,7 +118,7 @@ export const releaseCandidate: AgentConfig<TestnetChains> = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-58984b5',
+    tag: 'sha-7040e5c',
   },
   aws: {
     region: 'us-east-1',


### PR DESCRIPTION
* Deploy mostly to include #1087 and #1083
* Uses Gelato for alfajores, mumbai, and goerli on all testnet2 contexts